### PR TITLE
Add more encoding types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -272,9 +272,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1545,7 +1545,7 @@ impl TryFrom<&ListpackEntry> for String {
             .get_str()
             .map(|s| s.to_string())
             .ok_or_else(|| {
-                crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<String>(
+                crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<Self>(
                     encoding_type,
                 ))
             })
@@ -1559,7 +1559,7 @@ impl TryFrom<&ListpackEntry> for f64 {
         let encoding_type = entry.encoding_type()?;
 
         entry.data()?.get_f64().ok_or_else(|| {
-            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<f64>(
+            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<Self>(
                 encoding_type,
             ))
         })
@@ -1572,11 +1572,95 @@ impl TryFrom<&ListpackEntry> for i64 {
     fn try_from(entry: &ListpackEntry) -> Result<Self, Self::Error> {
         let encoding_type = entry.encoding_type()?;
 
-        entry.data()?.get_i64().ok_or_else(|| {
-            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<i64>(
+        entry.data()?.get_integer().ok_or_else(|| {
+            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<Self>(
                 encoding_type,
             ))
         })
+    }
+}
+
+impl TryFrom<&ListpackEntry> for i32 {
+    type Error = crate::error::Error;
+
+    fn try_from(entry: &ListpackEntry) -> Result<Self, Self::Error> {
+        let encoding_type = entry.encoding_type()?;
+        let integer: i64 = entry.data()?.get_integer().ok_or_else(|| {
+            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<Self>(
+                encoding_type,
+            ))
+        })?;
+
+        if ((Self::MIN as i64)..=(Self::MAX as i64)).contains(&integer) {
+            Ok(integer as Self)
+        } else {
+            Err(crate::error::Error::from(
+                crate::error::TypeConversionError::wrong_types::<Self>(encoding_type),
+            ))
+        }
+    }
+}
+
+impl TryFrom<&ListpackEntry> for i16 {
+    type Error = crate::error::Error;
+
+    fn try_from(entry: &ListpackEntry) -> Result<Self, Self::Error> {
+        let encoding_type = entry.encoding_type()?;
+        let integer: i64 = entry.data()?.get_integer().ok_or_else(|| {
+            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<Self>(
+                encoding_type,
+            ))
+        })?;
+
+        if ((Self::MIN as i64)..=(Self::MAX as i64)).contains(&integer) {
+            Ok(integer as Self)
+        } else {
+            Err(crate::error::Error::from(
+                crate::error::TypeConversionError::wrong_types::<Self>(encoding_type),
+            ))
+        }
+    }
+}
+
+impl TryFrom<&ListpackEntry> for i8 {
+    type Error = crate::error::Error;
+
+    fn try_from(entry: &ListpackEntry) -> Result<Self, Self::Error> {
+        let encoding_type = entry.encoding_type()?;
+        let integer: i64 = entry.data()?.get_integer().ok_or_else(|| {
+            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<Self>(
+                encoding_type,
+            ))
+        })?;
+
+        if ((Self::MIN as i64)..=(Self::MAX as i64)).contains(&integer) {
+            Ok(integer as Self)
+        } else {
+            Err(crate::error::Error::from(
+                crate::error::TypeConversionError::wrong_types::<Self>(encoding_type),
+            ))
+        }
+    }
+}
+
+impl TryFrom<&ListpackEntry> for u8 {
+    type Error = crate::error::Error;
+
+    fn try_from(entry: &ListpackEntry) -> Result<Self, Self::Error> {
+        let encoding_type = entry.encoding_type()?;
+        let integer: i64 = entry.data()?.get_integer().ok_or_else(|| {
+            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<Self>(
+                encoding_type,
+            ))
+        })?;
+
+        if ((Self::MIN as i64)..=(Self::MAX as i64)).contains(&integer) {
+            Ok(integer as Self)
+        } else {
+            Err(crate::error::Error::from(
+                crate::error::TypeConversionError::wrong_types::<Self>(encoding_type),
+            ))
+        }
     }
 }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1682,6 +1682,18 @@ impl<'a> From<&'a String> for ListpackEntryInsert<'a> {
     }
 }
 
+impl From<bool> for ListpackEntryInsert<'_> {
+    fn from(value: bool) -> Self {
+        Self::Boolean(value)
+    }
+}
+
+impl<'a> From<&'a bool> for ListpackEntryInsert<'a> {
+    fn from(value: &'a bool) -> Self {
+        Self::Boolean(*value)
+    }
+}
+
 macro_rules! impl_listpack_entry_insert_from_number {
     ($($t:ty),*) => {
         $(

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -964,7 +964,7 @@ impl<'a> From<ListpackEntryInsert<'a>> for ListpackEntryData<'a> {
 /// zero-sized object, which designates a reference to the actual
 /// listpack entry.
 #[repr(transparent)]
-pub struct ListpackEntry;
+pub struct ListpackEntry(());
 
 impl ListpackEntry {
     const ENCODING_TYPE_BYTE_LENGTH: usize = std::mem::size_of::<u8>();
@@ -1085,7 +1085,6 @@ impl ListpackEntry {
         let ptr = unsafe { (self as *const Self as *const u8).add(1) };
 
         match encoding_type {
-            // These share the same structure.
             ListpackEntryEncodingType::SmallUnsignedInteger => {
                 Some((unsafe { std::slice::from_raw_parts(ptr, 1) }, 2))
             }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1534,6 +1534,52 @@ impl MemoryConsumption for ListpackEntry {
     }
 }
 
+impl TryFrom<&ListpackEntry> for String {
+    type Error = crate::error::Error;
+
+    fn try_from(entry: &ListpackEntry) -> Result<Self, Self::Error> {
+        let encoding_type = entry.encoding_type()?;
+
+        entry
+            .data()?
+            .get_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<String>(
+                    encoding_type,
+                ))
+            })
+    }
+}
+
+impl TryFrom<&ListpackEntry> for f64 {
+    type Error = crate::error::Error;
+
+    fn try_from(entry: &ListpackEntry) -> Result<Self, Self::Error> {
+        let encoding_type = entry.encoding_type()?;
+
+        entry.data()?.get_f64().ok_or_else(|| {
+            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<f64>(
+                encoding_type,
+            ))
+        })
+    }
+}
+
+impl TryFrom<&ListpackEntry> for i64 {
+    type Error = crate::error::Error;
+
+    fn try_from(entry: &ListpackEntry) -> Result<Self, Self::Error> {
+        let encoding_type = entry.encoding_type()?;
+
+        entry.data()?.get_i64().ok_or_else(|| {
+            crate::error::Error::from(crate::error::TypeConversionError::wrong_types::<i64>(
+                encoding_type,
+            ))
+        })
+    }
+}
+
 /// The allowed types to be inserted into a listpack.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub enum ListpackEntryInsert<'a> {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -763,13 +763,17 @@ impl<'a> Encode for ListpackEntryData<'a> {
 
                 if data_length > 0 {
                     let data_length_length = count_bytes_in_number(data_length) as u8;
-                    block.append(&mut data_length_length.to_le_bytes().to_vec());
+                    block.push(data_length_length);
+
                     let mut data_length_length_bytes = data_length.to_le_bytes().to_vec();
                     while let Some(0) = data_length_length_bytes.last() {
                         data_length_length_bytes.pop();
                     }
+
                     block.append(&mut data_length_length_bytes);
                     block.append(&mut v.to_vec());
+                } else {
+                    block.push(0);
                 }
 
                 let mut length = encode_total_element_length(block.len())?;
@@ -2006,6 +2010,7 @@ mod tests {
                     ListpackEntrySubencodingType::CustomExtendedValue
                 )
             );
+
             assert_eq!(
                 decoded.data().unwrap().get_custom_extended().unwrap(),
                 &array

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -2,7 +2,7 @@
 
 use std::{ops::Deref, ptr::NonNull};
 
-use redis_custom_allocator::CustomAllocator;
+use redis_custom_allocator::{CustomAllocator, MemoryConsumption};
 
 use crate::{error::Result, Listpack};
 
@@ -53,11 +53,56 @@ pub enum ListpackEntrySubencodingType {
     /// the following four bits are `0100`. The following eight bytes of
     /// the data block represent a 64 bits signed integer.
     SignedInteger64Bit = 0b11110100,
+    /// A 64-bit floating-point number: the higher four bits are `1111`,
+    /// and the following four bits are `0101`. The following eight
+    /// bytes of the data block represent a 64 bits floating-point
+    /// number.
+    FloatingPoint64Bit = 0b11110101,
+    /// A boolean value: the value is embedded directly into the
+    /// encoding byte. The higher four bits are `1111`, the further
+    /// 3 bits are `011`, and the last remaining bit is the boolean
+    /// value itself.
+    Boolean = 0b11110110,
+    /// A custom embedded value. For example, a custom data structure
+    /// which data can be embedded into the entry header's last bit.
+    CustomEmbeddedValue = 0b11111000,
+    // TODO: this comment needs to be confirmed to comply with the spec
+    // and the maximum possible length, as it must not exceed the
+    // total-element-length length.
+    /// A custom extended value, whose data is stored in the data block.
+    /// The maximum length of the extended value is not limited by the
+    /// encoding type, but by the maximum size of the data block. The
+    /// interpretation of the data stored is up to the user.
+    ///
+    /// The extended value layout is as follows:
+    ///
+    /// <1 encoding byte> <1 byte count of the data length> <length> <data> <total-element-length>
+    ///
+    /// In case the data length is 0, the extended value layout is:
+    ///
+    /// <1 encoding byte> <0> <total-element-length>
+    ///
+    /// So the data and the length of the data are not stored at all,
+    /// which saves space. In case the data length is of one byte:
+    ///
+    /// <1 encoding byte> <1> <1 byte data length> <data> <total-element-length>
+    ///
+    /// Let's say we store a string "Hello":
+    ///
+    /// <11111010> <0b00000001> <0b00000101> "Hello" <total-element-length>
+    CustomExtendedValue = 0b11111010,
 }
 
 impl Encode for ListpackEntrySubencodingType {
     fn encode(&self) -> Result<Vec<u8>> {
-        Ok(vec![*self as u8])
+        // Handle the special cases of the internal encoding types.
+        match self {
+            // Only boolean and the custom embedded value have the value
+            // embedded into the encoding byte itself.
+            Self::Boolean => Ok(vec![0b1111_0110]),
+            Self::CustomEmbeddedValue => Ok(vec![0b1111_1000]),
+            _ => Ok(vec![*self as u8]),
+        }
     }
 }
 
@@ -66,15 +111,19 @@ impl TryFrom<u8> for ListpackEntrySubencodingType {
 
     fn try_from(encoding_byte: u8) -> Result<Self> {
         match encoding_byte {
-            0b11110000 => Ok(Self::LargeString),
-            0b11110001 => Ok(Self::SignedInteger16Bit),
-            0b11110010 => Ok(Self::SignedInteger24Bit),
-            0b11110011 => Ok(Self::SignedInteger32Bit),
-            0b11110100 => Ok(Self::SignedInteger64Bit),
+            0b1111_0101 => Ok(Self::FloatingPoint64Bit),
+            0b1111_0110 | 0b1111_0111 => Ok(Self::Boolean),
+            0b1111_1000 | 0b1111_1001 => Ok(Self::CustomEmbeddedValue),
+            0b1111_1010 => Ok(Self::CustomExtendedValue),
+            0b1111_0000 => Ok(Self::LargeString),
+            0b1111_0001 => Ok(Self::SignedInteger16Bit),
+            0b1111_0010 => Ok(Self::SignedInteger24Bit),
+            0b1111_0011 => Ok(Self::SignedInteger32Bit),
+            0b1111_0100 => Ok(Self::SignedInteger64Bit),
             _ => {
-                if encoding_byte & 0b11100000 == 0b11000000 {
+                if encoding_byte & 0b1110_0000 == 0b1100_0000 {
                     Ok(Self::SignedInteger13Bit)
-                } else if encoding_byte & 0b11110000 == 0b11100000 {
+                } else if encoding_byte & 0b1111_0000 == 0b1110_0000 {
                     Ok(Self::MediumString)
                 } else {
                     Err(crate::error::Error::UnknownEncodingType { encoding_byte })
@@ -144,6 +193,10 @@ impl From<ListpackEntryEncodingType> for u8 {
                 ListpackEntrySubencodingType::SignedInteger24Bit => 0b11110010,
                 ListpackEntrySubencodingType::SignedInteger32Bit => 0b11110011,
                 ListpackEntrySubencodingType::SignedInteger64Bit => 0b11110100,
+                ListpackEntrySubencodingType::FloatingPoint64Bit => 0b11110101,
+                ListpackEntrySubencodingType::Boolean => 0b11110110,
+                ListpackEntrySubencodingType::CustomEmbeddedValue => 0b11111000,
+                ListpackEntrySubencodingType::CustomExtendedValue => 0b11111010,
             },
         }
     }
@@ -170,6 +223,14 @@ pub enum ListpackEntryData<'a> {
     SignedInteger32Bit(i32),
     /// See [`ListpackEntrySubencodingType::SignedInteger64Bit`].
     SignedInteger64Bit(i64),
+    /// See [`ListpackEntrySubencodingType::FloatingPoint64Bit`].
+    FloatingPoint64Bit(f64),
+    /// See [`ListpackEntrySubencodingType::Boolean`].
+    Boolean(bool),
+    /// See [`ListpackEntrySubencodingType::CustomEmbeddedValue`].
+    CustomEmbeddedValue(u8),
+    /// See [`ListpackEntrySubencodingType::CustomExtendedValue`].
+    CustomExtendedValue(&'a [u8]),
 }
 
 impl ListpackEntryData<'_> {
@@ -200,6 +261,18 @@ impl ListpackEntryData<'_> {
             ),
             ListpackEntryData::SignedInteger64Bit(_) => ListpackEntryEncodingType::ComplexType(
                 ListpackEntrySubencodingType::SignedInteger64Bit,
+            ),
+            ListpackEntryData::FloatingPoint64Bit(_) => ListpackEntryEncodingType::ComplexType(
+                ListpackEntrySubencodingType::FloatingPoint64Bit,
+            ),
+            ListpackEntryData::Boolean(_) => {
+                ListpackEntryEncodingType::ComplexType(ListpackEntrySubencodingType::Boolean)
+            }
+            ListpackEntryData::CustomEmbeddedValue(_) => ListpackEntryEncodingType::ComplexType(
+                ListpackEntrySubencodingType::CustomEmbeddedValue,
+            ),
+            ListpackEntryData::CustomExtendedValue(_) => ListpackEntryEncodingType::ComplexType(
+                ListpackEntrySubencodingType::CustomExtendedValue,
             ),
         }
     }
@@ -286,6 +359,54 @@ impl ListpackEntryData<'_> {
         }
     }
 
+    /// Attempts to extract a 64-bit floating point value from the
+    /// entry.
+    pub fn get_f64(&self) -> Option<f64> {
+        match self {
+            ListpackEntryData::FloatingPoint64Bit(f) => Some(*f),
+            _ => None,
+        }
+    }
+
+    /// Attempts to extract a boolean value from the entry.
+    pub fn get_bool(&self) -> Option<bool> {
+        match self {
+            ListpackEntryData::Boolean(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    /// Attempts to extract a custom embedded value from the entry.
+    pub fn get_custom_embedded(&self) -> Option<u8> {
+        match self {
+            ListpackEntryData::CustomEmbeddedValue(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Attempts to extract a custom embedded value from the entry.
+    pub fn get_custom_extended(&self) -> Option<&[u8]> {
+        match self {
+            ListpackEntryData::CustomExtendedValue(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if the entry is a boolean.
+    pub fn is_bool(&self) -> bool {
+        self.get_bool().is_some()
+    }
+
+    /// Returns `true` if the entry is a custom embedded value.
+    pub fn is_custom_embedded(&self) -> bool {
+        self.get_custom_embedded().is_some()
+    }
+
+    /// Returns `true` if the entry is a custom extended value.
+    pub fn is_custom_extended(&self) -> bool {
+        self.get_custom_extended().is_some()
+    }
+
     /// Returns `true` if the entry is a small unsigned integer.
     pub fn is_u7(&self) -> bool {
         self.get_u7().is_some()
@@ -329,6 +450,11 @@ impl ListpackEntryData<'_> {
     /// Returns `true` if the entry is a signed 64-bit integer.
     pub fn is_i64(&self) -> bool {
         self.get_i64().is_some()
+    }
+
+    /// Returns `true` if the entry is a 64-bit floating point value.
+    pub fn is_f64(&self) -> bool {
+        self.get_f64().is_some()
     }
 
     /// Attempts to extract an integer from the entry.
@@ -443,11 +569,23 @@ fn calculate_total_element_length(object_length: usize) -> usize {
     // We need to take the "len" and count how many times we can split
     // it into 7-bit integers.
 
+    count_shifts(object_length, 7)
+}
+
+/// Returns the number of fully-utilised bytes required to store a value
+/// in the `number`.
+fn count_bytes_in_number(number: usize) -> usize {
+    count_shifts(number, 8)
+}
+
+/// Returns the number of bytes required to store a value in the
+/// `number`, when shifted by `shift_by`.
+fn count_shifts(number: usize, shift_by: u8) -> usize {
     let mut count = 1;
-    let mut remainder = object_length;
+    let mut remainder = number;
 
     loop {
-        remainder >>= 7;
+        remainder >>= shift_by;
 
         if remainder > 0 {
             count += 1;
@@ -594,6 +732,50 @@ impl<'a> Encode for ListpackEntryData<'a> {
                 block.append(&mut length);
                 block
             }
+            Self::FloatingPoint64Bit(f) => {
+                let mut block = vec![encoding_type_byte];
+
+                let mut data = f.to_le_bytes().to_vec();
+                block.append(&mut data);
+
+                let mut length = encode_total_element_length(block.len())?;
+                block.append(&mut length);
+                block
+            }
+            Self::Boolean(b) => {
+                let mut block = vec![encoding_type_byte | (*b as u8)];
+
+                let mut length = encode_total_element_length(block.len())?;
+                block.append(&mut length);
+                block
+            }
+            Self::CustomEmbeddedValue(v) => {
+                let mut block = vec![encoding_type_byte | *v];
+
+                let mut length = encode_total_element_length(block.len())?;
+                block.append(&mut length);
+                block
+            }
+            Self::CustomExtendedValue(v) => {
+                let mut block = vec![encoding_type_byte];
+
+                let data_length = v.len();
+
+                if data_length > 0 {
+                    let data_length_length = count_bytes_in_number(data_length) as u8;
+                    block.append(&mut data_length_length.to_le_bytes().to_vec());
+                    let mut data_length_length_bytes = data_length.to_le_bytes().to_vec();
+                    while let Some(0) = data_length_length_bytes.last() {
+                        data_length_length_bytes.pop();
+                    }
+                    block.append(&mut data_length_length_bytes);
+                    block.append(&mut v.to_vec());
+                }
+
+                let mut length = encode_total_element_length(block.len())?;
+                block.append(&mut length);
+                block
+            }
         })
     }
 }
@@ -616,6 +798,10 @@ impl std::fmt::Display for ListpackEntryData<'_> {
             ListpackEntryData::SignedInteger24Bit(i) => write!(f, "{i}"),
             ListpackEntryData::SignedInteger32Bit(i) => write!(f, "{i}"),
             ListpackEntryData::SignedInteger64Bit(i) => write!(f, "{i}"),
+            ListpackEntryData::FloatingPoint64Bit(v) => write!(f, "{v}"),
+            ListpackEntryData::Boolean(b) => write!(f, "{b}"),
+            ListpackEntryData::CustomEmbeddedValue(v) => write!(f, "{v}"),
+            ListpackEntryData::CustomExtendedValue(v) => write!(f, "{v:?}"),
         }
     }
 }
@@ -628,6 +814,14 @@ impl<'a> TryFrom<&'a ListpackEntryData<'a>> for ListpackEntryInsert<'a> {
             Ok(Self::String(data))
         } else if let Some(data) = data.get_i64() {
             Ok(Self::Integer(data))
+        } else if let Some(data) = data.get_f64() {
+            Ok(Self::Float(data))
+        } else if let Some(data) = data.get_bool() {
+            Ok(Self::Boolean(data))
+        } else if let Some(data) = data.get_custom_embedded() {
+            Ok(Self::CustomEmbeddedValue(data))
+        } else if let Some(data) = data.get_custom_extended() {
+            Ok(Self::CustomExtendedValue(data))
         } else {
             Err(crate::error::Error::UnknownEncodingType {
                 encoding_byte: data.encoding_type().into(),
@@ -636,7 +830,7 @@ impl<'a> TryFrom<&'a ListpackEntryData<'a>> for ListpackEntryInsert<'a> {
     }
 }
 
-macro_rules! impl_listpack_entry_data_from_number {
+macro_rules! impl_listpack_entry_data_from_integer {
     ($($t:ty),*) => {
         $(
             impl From<$t> for ListpackEntryData<'_> {
@@ -714,7 +908,7 @@ macro_rules! impl_listpack_entry_data_from_number {
     };
 }
 
-impl_listpack_entry_data_from_number!(i8, i16, i32, i64, u8, u16, u32, u64);
+impl_listpack_entry_data_from_integer!(i8, i16, i32, i64, u8, u16, u32, u64);
 
 impl<'a> From<&'a str> for ListpackEntryData<'a> {
     fn from(s: &'a str) -> Self {
@@ -735,11 +929,33 @@ impl<'a> From<&'a String> for ListpackEntryData<'a> {
     }
 }
 
+impl From<f64> for ListpackEntryData<'_> {
+    fn from(f: f64) -> Self {
+        Self::FloatingPoint64Bit(f)
+    }
+}
+
+impl From<bool> for ListpackEntryData<'_> {
+    fn from(b: bool) -> Self {
+        Self::Boolean(b)
+    }
+}
+
+impl<'a> From<&'a [u8]> for ListpackEntryData<'a> {
+    fn from(v: &'a [u8]) -> Self {
+        Self::CustomExtendedValue(v)
+    }
+}
+
 impl<'a> From<ListpackEntryInsert<'a>> for ListpackEntryData<'a> {
     fn from(insert: ListpackEntryInsert<'a>) -> Self {
         match insert {
             ListpackEntryInsert::String(s) => Self::from(s),
             ListpackEntryInsert::Integer(i) => Self::from(i),
+            ListpackEntryInsert::Float(f) => Self::from(f),
+            ListpackEntryInsert::Boolean(b) => Self::from(b),
+            ListpackEntryInsert::CustomEmbeddedValue(v) => Self::CustomEmbeddedValue(v),
+            ListpackEntryInsert::CustomExtendedValue(v) => Self::from(v),
         }
     }
 }
@@ -869,6 +1085,7 @@ impl ListpackEntry {
         let ptr = unsafe { (self as *const Self as *const u8).add(1) };
 
         match encoding_type {
+            // These share the same structure.
             ListpackEntryEncodingType::SmallUnsignedInteger => {
                 Some((unsafe { std::slice::from_raw_parts(ptr, 1) }, 2))
             }
@@ -948,13 +1165,44 @@ impl ListpackEntry {
                     };
                     Some(data)
                 }
-                ListpackEntrySubencodingType::SignedInteger64Bit => {
+                // These two share the same structure.
+                ListpackEntrySubencodingType::SignedInteger64Bit
+                | ListpackEntrySubencodingType::FloatingPoint64Bit => {
                     let data = unsafe {
                         let data = std::slice::from_raw_parts(ptr, 8);
                         let total_bytes = Self::ENCODING_TYPE_BYTE_LENGTH + 8 + 1;
                         (data, total_bytes)
                     };
                     Some(data)
+                }
+                ListpackEntrySubencodingType::CustomExtendedValue => {
+                    let data = unsafe {
+                        let extended_length = *ptr.add(0) as usize;
+
+                        let mut data_len = 0;
+
+                        for i in 0..extended_length {
+                            data_len = (data_len << 8) | (*ptr.add(1 + i) as usize);
+                        }
+
+                        if data_len == 0 {
+                            return Some((&[], 3));
+                        }
+
+                        let ptr = ptr.add(extended_length);
+                        let data = std::slice::from_raw_parts(ptr.add(1), data_len);
+                        let extra_length = Self::ENCODING_TYPE_BYTE_LENGTH + extended_length;
+                        let object_length = data_len + extra_length;
+                        let total_bytes =
+                            object_length + calculate_total_element_length(object_length);
+                        (data, total_bytes)
+                    };
+                    Some(data)
+                }
+                // The value is stored in the entry header itself.
+                ListpackEntrySubencodingType::Boolean
+                | ListpackEntrySubencodingType::CustomEmbeddedValue => {
+                    Some((unsafe { std::slice::from_raw_parts(ptr, 1) }, 2))
                 }
             },
         }
@@ -1093,6 +1341,27 @@ impl ListpackEntry {
                         | (data[0] as i64);
                     ListpackEntryData::SignedInteger64Bit(n)
                 }
+                ListpackEntrySubencodingType::FloatingPoint64Bit => {
+                    let data = self
+                        .get_data_raw()
+                        .ok_or(crate::error::Error::MissingDataBlock)?;
+                    let n = f64::from_le_bytes(data.try_into().unwrap());
+                    ListpackEntryData::FloatingPoint64Bit(n)
+                }
+                ListpackEntrySubencodingType::Boolean => {
+                    let value = encoding_type_byte & 0b00000001 == 1;
+                    ListpackEntryData::Boolean(value)
+                }
+                ListpackEntrySubencodingType::CustomEmbeddedValue => {
+                    let value = encoding_type_byte & 0b00000001;
+                    ListpackEntryData::CustomEmbeddedValue(value)
+                }
+                ListpackEntrySubencodingType::CustomExtendedValue => {
+                    let data = self
+                        .get_data_raw()
+                        .ok_or(crate::error::Error::MissingDataBlock)?;
+                    ListpackEntryData::CustomExtendedValue(data)
+                }
             },
         })
     }
@@ -1131,11 +1400,47 @@ impl PartialEq<i64> for ListpackEntry {
     }
 }
 
+impl PartialEq<f64> for ListpackEntry {
+    fn eq(&self, other: &f64) -> bool {
+        self.data()
+            .map(|data| data.get_f64() == Some(*other))
+            .unwrap_or(false)
+    }
+}
+
+impl PartialEq<bool> for ListpackEntry {
+    fn eq(&self, other: &bool) -> bool {
+        self.data()
+            .map(|data| data.get_bool() == Some(*other))
+            .unwrap_or(false)
+    }
+}
+
+impl PartialEq<u8> for ListpackEntry {
+    fn eq(&self, other: &u8) -> bool {
+        self.data()
+            .map(|data| data.get_custom_embedded() == Some(*other))
+            .unwrap_or(false)
+    }
+}
+
+impl PartialEq<&[u8]> for ListpackEntry {
+    fn eq(&self, other: &&[u8]) -> bool {
+        self.data()
+            .map(|data| data.get_custom_extended() == Some(*other))
+            .unwrap_or(false)
+    }
+}
+
 impl PartialEq<ListpackEntryInsert<'_>> for ListpackEntry {
     fn eq(&self, other: &ListpackEntryInsert) -> bool {
         match other {
             ListpackEntryInsert::String(s) => self == *s,
             ListpackEntryInsert::Integer(n) => self == n,
+            ListpackEntryInsert::Float(f) => self == f,
+            ListpackEntryInsert::Boolean(b) => self == b,
+            ListpackEntryInsert::CustomEmbeddedValue(v) => *self == *v,
+            ListpackEntryInsert::CustomExtendedValue(v) => *self == *v,
         }
     }
 }
@@ -1145,6 +1450,10 @@ impl PartialEq<ListpackEntryInsert<'_>> for &ListpackEntry {
         match other {
             ListpackEntryInsert::String(s) => *self == *s,
             ListpackEntryInsert::Integer(n) => *self == n,
+            ListpackEntryInsert::Float(f) => *self == f,
+            ListpackEntryInsert::Boolean(b) => *self == b,
+            ListpackEntryInsert::CustomEmbeddedValue(v) => **self == *v,
+            ListpackEntryInsert::CustomExtendedValue(v) => **self == *v,
         }
     }
 }
@@ -1171,13 +1480,27 @@ impl std::fmt::Display for ListpackEntry {
     }
 }
 
+impl MemoryConsumption for ListpackEntry {
+    fn memory_consumption(&self) -> usize {
+        self.total_bytes()
+    }
+}
+
 /// The allowed types to be inserted into a listpack.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub enum ListpackEntryInsert<'a> {
     /// A string to insert into a listpack.
     String(&'a str),
     /// An integer to insert into a listpack.
     Integer(i64),
+    /// A float to insert into a listpack.
+    Float(f64),
+    /// A boolean to insert into a listpack.
+    Boolean(bool),
+    /// A custom value to be embedded into an entry in a listpack.
+    CustomEmbeddedValue(u8),
+    /// A bigger custom value to be inserted into a listpack.
+    CustomExtendedValue(&'a [u8]),
 }
 
 impl ListpackEntryInsert<'_> {
@@ -1253,6 +1576,36 @@ impl ListpackEntryInsert<'_> {
                     10
                 }
             }
+            Self::Float(_) => {
+                // 1: encoding byte.
+                // 8: 64-bit float.
+                // 1: total-byte-length of one byte.
+                10
+            }
+            Self::Boolean(_) => {
+                // 1: encoding byte and the boolean value.
+                // 1: total-byte-length of one byte.
+                2
+            }
+            Self::CustomEmbeddedValue(_) => {
+                // 1: encoding byte and the custom value.
+                // 1: total-byte-length of one byte.
+                2
+            }
+            Self::CustomExtendedValue(v) => {
+                // 1: encoding byte.
+                // 1: the length of the extended value (m).
+                // 1-m: the extended value length.
+                // n: the extended value.
+                // 1: total-byte-length of one byte.
+                if v.is_empty() {
+                    3
+                } else {
+                    let data_length = v.len();
+                    let extended_length = count_bytes_in_number(data_length);
+                    2 + extended_length + data_length + 1
+                }
+            }
         }
     }
 }
@@ -1302,12 +1655,20 @@ macro_rules! impl_listpack_entry_insert_from_number {
 impl_listpack_entry_insert_from_number!(i8, i16, i32, i64, u8, u16, u32, u64);
 
 /// The listpack entry which is removed from listpack.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub enum ListpackEntryRemoved {
     /// A string which was removed from a listpack.
     String(String),
     /// An integer which was removed from a listpack.
     Integer(i64),
+    /// A floating point value which was removed from a listpack.
+    Float(f64),
+    /// A boolean value which was removed from a listpack.
+    Boolean(bool),
+    /// A custom embedded value which was removed from a listpack.
+    CustomEmbeddedValue(u8),
+    /// A custom extended value which was removed from a listpack.
+    CustomExtendedValue(Vec<u8>),
 }
 
 impl ListpackEntryRemoved {
@@ -1353,6 +1714,10 @@ impl std::fmt::Display for ListpackEntryRemoved {
         match self {
             Self::String(s) => write!(f, "{s}"),
             Self::Integer(n) => write!(f, "{n}"),
+            Self::Float(n) => write!(f, "{n}"),
+            Self::CustomEmbeddedValue(v) => write!(f, "{:?}", v),
+            Self::CustomExtendedValue(v) => write!(f, "{:?}", v),
+            Self::Boolean(b) => write!(f, "{b}"),
         }
     }
 }
@@ -1371,20 +1736,7 @@ impl From<&String> for ListpackEntryRemoved {
 
 impl From<NonNull<u8>> for ListpackEntryRemoved {
     fn from(ptr: NonNull<u8>) -> Self {
-        let entry = ListpackEntry::ref_from_ptr(ptr);
-        let data = entry.data().unwrap();
-
-        match data {
-            ListpackEntryData::SmallString(s)
-            | ListpackEntryData::MediumString(s)
-            | ListpackEntryData::LargeString(s) => Self::String(s.to_owned()),
-            ListpackEntryData::SignedInteger13Bit(n) => Self::Integer(n as i64),
-            ListpackEntryData::SignedInteger16Bit(n) => Self::Integer(n as i64),
-            ListpackEntryData::SignedInteger24Bit(n) => Self::Integer(n as i64),
-            ListpackEntryData::SignedInteger32Bit(n) => Self::Integer(n as i64),
-            ListpackEntryData::SignedInteger64Bit(n) => Self::Integer(n),
-            ListpackEntryData::SmallUnsignedInteger(u) => Self::Integer(u as i64),
-        }
+        Self::from(ListpackEntry::ref_from_ptr(ptr))
     }
 }
 
@@ -1408,6 +1760,10 @@ impl From<&ListpackEntry> for ListpackEntryRemoved {
             ListpackEntryData::SignedInteger32Bit(n) => Self::Integer(n as i64),
             ListpackEntryData::SignedInteger64Bit(n) => Self::Integer(n),
             ListpackEntryData::SmallUnsignedInteger(u) => Self::Integer(u as i64),
+            ListpackEntryData::FloatingPoint64Bit(n) => Self::Float(n),
+            ListpackEntryData::Boolean(b) => Self::Boolean(b),
+            ListpackEntryData::CustomEmbeddedValue(v) => Self::CustomEmbeddedValue(v),
+            ListpackEntryData::CustomExtendedValue(v) => Self::CustomExtendedValue(v.to_vec()),
         }
     }
 }
@@ -1417,6 +1773,10 @@ impl<'a> From<&'a ListpackEntryRemoved> for ListpackEntryInsert<'a> {
         match removed {
             ListpackEntryRemoved::String(s) => Self::String(s),
             ListpackEntryRemoved::Integer(n) => Self::Integer(*n),
+            ListpackEntryRemoved::Float(n) => Self::Float(*n),
+            ListpackEntryRemoved::Boolean(b) => Self::Boolean(*b),
+            ListpackEntryRemoved::CustomEmbeddedValue(v) => Self::CustomEmbeddedValue(*v),
+            ListpackEntryRemoved::CustomExtendedValue(v) => Self::CustomExtendedValue(v),
         }
     }
 }
@@ -1564,6 +1924,94 @@ mod tests {
                 encode_total_element_length(34359738367).unwrap(),
                 vec![0b01111111, 0b11111111, 0b11111111, 0b11111111, 0b11111111]
             );
+        }
+
+        #[test]
+        fn entry_bool() {
+            let entry = ListpackEntryInsert::Boolean(false);
+            let encoded = entry.encode().unwrap();
+            let decoded = ListpackEntry::ref_from_slice(encoded.as_slice());
+            let ty = decoded.encoding_type().unwrap();
+            assert_eq!(
+                ty,
+                ListpackEntryEncodingType::ComplexType(ListpackEntrySubencodingType::Boolean)
+            );
+            assert!(!decoded.data().unwrap().get_bool().unwrap());
+
+            let entry = ListpackEntryInsert::Boolean(true);
+            let encoded = entry.encode().unwrap();
+            let decoded = ListpackEntry::ref_from_slice(encoded.as_slice());
+            assert!(decoded.data().unwrap().get_bool().unwrap());
+        }
+
+        #[test]
+        fn entry_f64() {
+            let entry = ListpackEntryInsert::Float(55.66f64);
+            let encoded = entry.encode().unwrap();
+            let decoded = ListpackEntry::ref_from_slice(encoded.as_slice());
+            let ty = decoded.encoding_type().unwrap();
+            assert_eq!(
+                ty,
+                ListpackEntryEncodingType::ComplexType(
+                    ListpackEntrySubencodingType::FloatingPoint64Bit
+                )
+            );
+            assert_eq!(decoded.data().unwrap().get_f64().unwrap(), 55.66f64);
+        }
+
+        #[test]
+        fn entry_custom_embedded() {
+            let entry = ListpackEntryInsert::CustomEmbeddedValue(0);
+            let encoded = entry.encode().unwrap();
+            let decoded = ListpackEntry::ref_from_slice(encoded.as_slice());
+            let ty = decoded.encoding_type().unwrap();
+            assert_eq!(
+                ty,
+                ListpackEntryEncodingType::ComplexType(
+                    ListpackEntrySubencodingType::CustomEmbeddedValue
+                )
+            );
+            assert_eq!(decoded.data().unwrap().get_custom_embedded().unwrap(), 0);
+        }
+
+        #[test]
+        fn entry_custom_extended_non_empty() {
+            let array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+            let entry = ListpackEntryInsert::CustomExtendedValue(&array);
+            let encoded = entry.encode().unwrap();
+            let decoded = ListpackEntry::ref_from_slice(encoded.as_slice());
+            let ty = decoded.encoding_type().unwrap();
+            assert_eq!(
+                ty,
+                ListpackEntryEncodingType::ComplexType(
+                    ListpackEntrySubencodingType::CustomExtendedValue
+                )
+            );
+            assert_eq!(
+                decoded.data().unwrap().get_custom_extended().unwrap(),
+                &array
+            );
+            assert_eq!(decoded.total_bytes(), 13);
+        }
+
+        #[test]
+        fn entry_custom_extended_empty() {
+            let array = [];
+            let entry = ListpackEntryInsert::CustomExtendedValue(&array);
+            let encoded = entry.encode().unwrap();
+            let decoded = ListpackEntry::ref_from_slice(encoded.as_slice());
+            let ty = decoded.encoding_type().unwrap();
+            assert_eq!(
+                ty,
+                ListpackEntryEncodingType::ComplexType(
+                    ListpackEntrySubencodingType::CustomExtendedValue
+                )
+            );
+            assert_eq!(
+                decoded.data().unwrap().get_custom_extended().unwrap(),
+                &array
+            );
+            assert_eq!(decoded.total_bytes(), 3);
         }
 
         #[test]

--- a/src/listpack.rs
+++ b/src/listpack.rs
@@ -3267,7 +3267,7 @@ mod tests {
                 }
                 ListpackEntryInsert::CustomExtendedValue(value) => {
                     assert_eq!(
-                        data.get_custom_extended().unwrap(),
+                        data.get_custom_extended::<'_, &[u8]>().unwrap(),
                         *value,
                         "with object: {object:?}"
                     );

--- a/src/listpack.rs
+++ b/src/listpack.rs
@@ -3225,6 +3225,12 @@ mod tests {
             ListpackEntryInsert::Integer(4_088_608),
             ListpackEntryInsert::Integer(1_047_483_648),
             ListpackEntryInsert::Integer(4_023_372_036_854_775_807),
+            ListpackEntryInsert::Boolean(true),
+            ListpackEntryInsert::Boolean(false),
+            ListpackEntryInsert::Float(42.23f64),
+            ListpackEntryInsert::CustomEmbeddedValue(0),
+            ListpackEntryInsert::CustomEmbeddedValue(1),
+            ListpackEntryInsert::CustomExtendedValue(&[0, 1, 2, 3]),
         ];
 
         for object in &objects {
@@ -3241,6 +3247,30 @@ mod tests {
                 }
                 ListpackEntryInsert::String(string) => {
                     assert_eq!(data.get_str().unwrap(), *string, "with object: {object:?}");
+                }
+                ListpackEntryInsert::Boolean(boolean) => {
+                    assert_eq!(
+                        data.get_bool().unwrap(),
+                        *boolean,
+                        "with object: {object:?}"
+                    );
+                }
+                ListpackEntryInsert::Float(float) => {
+                    assert_eq!(data.get_f64().unwrap(), *float, "with object: {object:?}");
+                }
+                ListpackEntryInsert::CustomEmbeddedValue(value) => {
+                    assert_eq!(
+                        data.get_custom_embedded().unwrap(),
+                        *value,
+                        "with object: {object:?}"
+                    );
+                }
+                ListpackEntryInsert::CustomExtendedValue(value) => {
+                    assert_eq!(
+                        data.get_custom_extended().unwrap(),
+                        *value,
+                        "with object: {object:?}"
+                    );
                 }
             }
         }

--- a/src/listpack.rs
+++ b/src/listpack.rs
@@ -571,16 +571,15 @@ where
             .map(ListpackEntryInsert::full_encoded_size)
             .sum();
         let mut listpack = Listpack::with_capacity(elements_size);
-        let mut ptr = listpack.allocation.data_start_ptr();
+        let ptr = listpack.allocation.data_start_ptr();
 
-        for item in items {
-            let mut encoded = item.encode().expect("Encoded value");
+        let encoded: Vec<u8> = items
+            .iter()
+            .flat_map(|item| item.encode().expect("Encoded value"))
+            .collect();
 
-            unsafe {
-                std::ptr::copy_nonoverlapping(encoded.as_mut_ptr(), ptr.cast_mut(), encoded.len());
-            }
-
-            ptr = unsafe { ptr.add(encoded.len()) };
+        unsafe {
+            std::ptr::copy_nonoverlapping(encoded.as_ptr(), ptr.cast_mut(), encoded.len());
         }
 
         listpack.set_num_elements(slice.len() as u16);
@@ -608,16 +607,15 @@ where
             .sum();
 
         let mut listpack = Listpack::with_capacity(elements_size);
-        let mut ptr = listpack.allocation.data_start_ptr();
+        let ptr = listpack.allocation.data_start_ptr();
 
-        for item in items {
-            let mut encoded = item.encode().expect("Encoded value");
+        let encoded: Vec<u8> = items
+            .iter()
+            .flat_map(|item| item.encode().expect("Encoded value"))
+            .collect();
 
-            unsafe {
-                std::ptr::copy_nonoverlapping(encoded.as_mut_ptr(), ptr.cast_mut(), encoded.len());
-            }
-
-            ptr = unsafe { ptr.add(encoded.len()) };
+        unsafe {
+            std::ptr::copy_nonoverlapping(encoded.as_ptr(), ptr.cast_mut(), encoded.len());
         }
 
         listpack.set_num_elements(N as u16);
@@ -657,16 +655,15 @@ where
         let items_len = items.len();
 
         let mut listpack = Listpack::with_capacity(elements_size);
-        let mut ptr = listpack.allocation.data_start_ptr();
+        let ptr = listpack.allocation.data_start_ptr();
 
-        for item in items {
-            let mut encoded = item.encode().expect("Encoded value");
+        let encoded: Vec<u8> = items
+            .iter()
+            .flat_map(|item| item.encode().expect("Encoded value"))
+            .collect();
 
-            unsafe {
-                std::ptr::copy_nonoverlapping(encoded.as_mut_ptr(), ptr.cast_mut(), encoded.len());
-            }
-
-            ptr = unsafe { ptr.add(encoded.len()) };
+        unsafe {
+            std::ptr::copy_nonoverlapping(encoded.as_ptr(), ptr.cast_mut(), encoded.len());
         }
 
         listpack.set_num_elements(items_len as u16);


### PR DESCRIPTION
Adds more types to the list pack to store:

1. Booleans (`true` and `false`).
2. Double-precision floating point value (`f64`).
3. Custom object types which can be embedded into a single bit (two possible values).
4. Custom object types which cannot be embedded and require extra space. Such values are stored as bytes.